### PR TITLE
Unicode patches

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -507,7 +507,7 @@ You can also submit a pre-made request encoded as WPS XML:
 
 .. code-block:: python
 
-	>>> request = open('/Users/cinquini/Documents/workspace-cog/wps/tests/resources/wps_USGSExecuteRequest1.xml','r').read()
+	>>> request = open('/Users/cinquini/Documents/workspace-cog/wps/tests/resources/wps_USGSExecuteRequest1.xml','rb').read()
 	>>> execution = wps.execute(None, [], request=request)
 	Executing WPS request...
 	Execution status=ProcessStarted

--- a/examples/wps-client.py
+++ b/examples/wps-client.py
@@ -83,7 +83,7 @@ for opt, arg in options:
     elif opt in ('-r', '--request'):
         request = arg
     elif opt in ('-x', '--xml'):
-        xml = open(arg, 'r').read()
+        xml = open(arg, 'rb').read()
     elif opt in ('-i', '--identifier'):
         identifier = arg
     elif opt in ('-v', '--verbose'):

--- a/examples/wps-pml-script-2.py
+++ b/examples/wps-pml-script-2.py
@@ -21,7 +21,7 @@ for process in wps.processes:
 # 2) DescribeProcess
 process = wps.describeprocess('v.net.path')
 # alternatively, read process description from XML file (no live request to WPS server)
-#xml = open('../tests/USGSDescribeProcess.xml', 'r').read()
+#xml = open('../tests/USGSDescribeProcess.xml', 'rb').read()
 #process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm', xml=xml)
 print('WPS Process: identifier=%s' % process.identifier)
 print('WPS Process: title=%s' % process.title)

--- a/examples/wps-usgs-script.py
+++ b/examples/wps-usgs-script.py
@@ -15,7 +15,7 @@ wps = WebProcessingService('http://cida.usgs.gov/climate/gdp/process/WebProcessi
 
 wps.getcapabilities()
 # alternatively, read capabilities from XML file (no live request to WPS server)
-#xml = open('../tests/USGSCapabilities.xml', 'r').read() 
+#xml = open('../tests/USGSCapabilities.xml', 'rb').read() 
 #wps.getcapabilities(xml=xml)
 print('WPS Identification type: %s' % wps.identification.type)
 print('WPS Identification title: %s' % wps.identification.title)
@@ -30,7 +30,7 @@ for process in wps.processes:
 
 process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm')
 # alternatively, read process description from XML file (no live request to WPS server)
-#xml = open('../tests/USGSDescribeProcess.xml', 'r').read()
+#xml = open('../tests/USGSDescribeProcess.xml', 'rb').read()
 #process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm', xml=xml)
 print('WPS Process: identifier=%s' % process.identifier)
 print('WPS Process: title=%s' % process.title)
@@ -68,7 +68,7 @@ inputs = [ ("FEATURE_ATTRIBUTE_NAME","the_geom"),
 output = "OUTPUT"
 execution = wps.execute(processid, inputs, output = "OUTPUT")
 # alternatively, submit a pre-made request specified in an XML file
-#request = open('../tests/wps_USGSExecuteRequest1.xml','r').read()
+#request = open('../tests/wps_USGSExecuteRequest1.xml','rb').read()
 #execution = wps.execute(None, [], request=request)
 
 # The monitorExecution() function can be conveniently used to wait for the process termination
@@ -105,7 +105,7 @@ inputs =  [ ("FEATURE_ATTRIBUTE_NAME","the_geom"),
 output = "OUTPUT"
 execution = wps.execute(processid, inputs, output = "OUTPUT")
 # alternatively, submit a pre-made request specified in an XML file
-#request = open('../tests/wps_USGSExecuteRequest3.xml','r').read()
+#request = open('../tests/wps_USGSExecuteRequest3.xml','rb').read()
 #execution = wps.execute(None, [], request=request)
 monitorExecution(execution)    
 '''

--- a/owslib/feature/wfs100.py
+++ b/owslib/feature/wfs100.py
@@ -400,7 +400,7 @@ class WFSCapabilitiesReader(object):
 
         string should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, str) and not isinstance(st, bytes):
+            raise ValueError("String must be of type string or bytes, not %s" % type(st))
         return etree.fromstring(st)
     

--- a/owslib/feature/wfs200.py
+++ b/owslib/feature/wfs200.py
@@ -453,6 +453,6 @@ class WFSCapabilitiesReader(object):
 
         string should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, str) and not isinstance(st, bytes):
+            raise ValueError("String must be of type string or bytes, not %s" % type(st))
         return etree.fromstring(st)

--- a/owslib/swe/observation/sos200.py
+++ b/owslib/swe/observation/sos200.py
@@ -320,6 +320,6 @@ class SosCapabilitiesReader(object):
 
             st should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, str) and not isinstance(st, bytes):
+            raise ValueError("String must be of type string or bytes, not %s" % type(st))
         return etree.fromstring(st)

--- a/owslib/swe/sensor/sml.py
+++ b/owslib/swe/sensor/sml.py
@@ -19,7 +19,7 @@ def nsp(path):
 
 class SensorML(object):
     def __init__(self, element):
-        if isinstance(element, str):
+        if isinstance(element, str) or isinstance(element, bytes):
             self._root = etree.fromstring(element)
         else:
             self._root = element

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -637,6 +637,6 @@ class WMSCapabilitiesReader:
 
         string should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            raise ValueError("String must be of type string, not %s" % type(st))
+        if not isinstance(st, str) and not isinstance(st, bytes):
+            raise ValueError("String must be of type string or bytes, not %s" % type(st))
         return etree.fromstring(st)

--- a/owslib/wmts.py
+++ b/owslib/wmts.py
@@ -741,7 +741,7 @@ class WMTSCapabilitiesReader:
 
         string should be an XML capabilities document
         """
-        if not isinstance(st, str):
-            msg = 'String must be of type string, not %s' % type(st)
+        if not isinstance(st, str) and not isinstance(st, bytes):
+            msg = 'String must be of type string or bytes, not %s' % type(st)
             raise ValueError(msg)
         return etree.fromstring(st)

--- a/owslib/wps.py
+++ b/owslib/wps.py
@@ -377,7 +377,7 @@ class WPSReader(object):
         Method to read a WPS GetCapabilities document from an XML string.
         """
         
-        if not isinstance(string, str):
+        if not isinstance(string, str) and not isinstance(string, bytes):
             raise ValueError("Input must be of type string, not %s" % type(string))
         return etree.fromstring(string)    
 

--- a/tests/doctests/csw_uuid_constrain.txt
+++ b/tests/doctests/csw_uuid_constrain.txt
@@ -77,7 +77,7 @@ Initialize CSW client
     # Test 5
     # construct a request by send the xml string
     ##########################################################
-    >>> sos_search='''<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+    >>> sos_search=b'''<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
     ... <csw:GetRecords xmlns:xs2="http://www.w3.org/XML/Schema" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:gml="http://www.opengis.net/gml" xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:ows="http://www.opengis.net/ows" xmlns:fgdc="http://www.opengis.net/cat/csw/csdgm" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dct="http://purl.org/dc/terms/" xmlns:ogc="http://www.opengis.net/ogc" outputSchema="http://www.opengis.net/cat/csw/2.0.2" outputFormat="application/xml" version="2.0.2" resultType="results" service="CSW" maxRecords="10" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd">
     ... <csw:Query typeNames="csw:Record">
     ... <csw:ElementSetName>full</csw:ElementSetName>

--- a/tests/doctests/ows_interfaces.txt
+++ b/tests/doctests/ows_interfaces.txt
@@ -12,8 +12,8 @@
 
 #TODO, we should run all these from local XML documents (as per the WMS and WFS services)
 
-    >>> wmsxml = open(resource_file('wms_JPLCapabilities.xml'), 'r').read() 
-    >>> wfsxml = open(resource_file('mapserver-wfs-cap.xml'), 'r').read()
+    >>> wmsxml = open(resource_file('wms_JPLCapabilities.xml'), 'rb').read() 
+    >>> wfsxml = open(resource_file('mapserver-wfs-cap.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=wmsxml)
     >>> wfs = WebFeatureService('url', version='1.0', xml=wfsxml)
     >>> wcs=WebCoverageService('http://thredds.ucar.edu/thredds/wcs/grib/NCEP/NAM/CONUS_80km/best', version='1.0.0')

--- a/tests/doctests/sml_52n_network.txt
+++ b/tests/doctests/sml_52n_network.txt
@@ -8,7 +8,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sml_52N_network.xml'), 'r').read()
+    >>> xml = open(resource_file('sml_52N_network.xml'), 'rb').read()
     >>> root = SensorML(xml)
     >>> system = root.members[0]
 

--- a/tests/doctests/sml_52n_network.txt
+++ b/tests/doctests/sml_52n_network.txt
@@ -17,7 +17,7 @@ Initialize
 
 Contacts
 
-    >>> system.contacts.keys()
+    >>> list(system.contacts.keys())
     ['http://mmisw.org/ont/ioos/definition/publisher']
 
     >>> publishers = system.get_contacts_by_role('http://mmisw.org/ont/ioos/definition/publisher')
@@ -32,7 +32,7 @@ Contacts
 
 Identification
 
-    >>> sorted(system.identifiers.keys())
+    >>> sorted(list(system.identifiers.keys()))
     ['longName', 'networkID', 'shortName']
 
     >>> sid = system.get_identifiers_by_name('networkID')
@@ -45,7 +45,7 @@ Identification
 
 Classifiers
 
-    >>> sorted(system.classifiers.keys())
+    >>> sorted(list(system.classifiers.keys()))
     ['parentNetwork', 'publisher']
     >>> classi = system.get_classifiers_by_name('publisher')
     >>> classi[0].definition
@@ -55,12 +55,12 @@ Classifiers
 
 Capabilities
 
-    >>> sorted(system.capabilities.keys())
+    >>> sorted(list(system.capabilities.keys()))
     ['featuresOfInterest', 'observationTimeRange', 'observedBBOX', 'offerings']
 
 Characteristics
 
-    >>> system.characteristics.keys()
+    >>> list(system.characteristics.keys())
     []
 
 Components

--- a/tests/doctests/sml_ndbc_station.txt
+++ b/tests/doctests/sml_ndbc_station.txt
@@ -8,7 +8,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sml_ndbc_station.xml'), 'r').read()
+    >>> xml = open(resource_file('sml_ndbc_station.xml'), 'rb').read()
     >>> root = SensorML(xml)
     >>> system = root.members[0]
 

--- a/tests/doctests/sos_10_getcapabilities.txt
+++ b/tests/doctests/sos_10_getcapabilities.txt
@@ -12,17 +12,17 @@ Imports
 
 Initialize ncSOS
 
-    >>> xml = open(resource_file('sos_ncSOS_getcapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_ncSOS_getcapabilities.xml'), 'rb').read()
     >>> ncsos = SensorObservationService(None, xml=xml)
 
 Initialize 52N
 
-    >>> xml = open(resource_file('sos_52n_getcapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_52n_getcapabilities.xml'), 'rb').read()
     >>> f2n = SensorObservationService(None, xml=xml)
 
 Initialize NDBC
 
-    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'), 'rb').read()
     >>> ndbc = SensorObservationService(None, xml=xml)
 
 ServiceIdentification

--- a/tests/doctests/sos_10_ndbc_getobservation.txt
+++ b/tests/doctests/sos_10_ndbc_getobservation.txt
@@ -11,7 +11,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'),'r').read()
+    >>> xml = open(resource_file('sos_ndbc_getcapabilities.xml'),'rb').read()
     >>> ndbc = SensorObservationService(None, xml=xml)
 
 

--- a/tests/doctests/sos_ngmp.txt
+++ b/tests/doctests/sos_ngmp.txt
@@ -12,7 +12,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sos_ngmp.xml'), 'r').read()
+    >>> xml = open(resource_file('sos_ngmp.xml'), 'rb').read()
     >>> ngmp = SensorObservationService(None, xml=xml, version='2.0.0')
 
 ServiceIdentification

--- a/tests/doctests/sos_ngwd.txt
+++ b/tests/doctests/sos_ngwd.txt
@@ -12,7 +12,7 @@ Imports
 
 Initialize
 
-    >>> xml = open(resource_file('sos_ngwd.xml'),'r').read()
+    >>> xml = open(resource_file('sos_ngwd.xml'),'rb').read()
     >>> ngwd = SensorObservationService(None, xml=xml, version='2.0.0')
 
 ServiceIdentification

--- a/tests/doctests/swe_common_20.txt
+++ b/tests/doctests/swe_common_20.txt
@@ -7,7 +7,7 @@ Imports
 
 Initialize
 
-    >>> swexml  = open(resource_file('swe_ioos_multistation_timeseries.xml'), 'r').read()
+    >>> swexml  = open(resource_file('swe_ioos_multistation_timeseries.xml'), 'rb').read()
     >>> dr      = etree.fromstring(swexml)
     >>> if hasattr(dr, 'getroot'):
     ...     dr = dr.getroot()

--- a/tests/doctests/wfs2_generic.txt
+++ b/tests/doctests/wfs2_generic.txt
@@ -4,7 +4,7 @@ Imports and initialize
     >>> from owslib.wfs import WebFeatureService
     >>> from tests.utils import resource_file, sorted_url_query
 
-    >>> getcapsin = open(resource_file("wfs_CUZK_GetCapabilities_2_0_0.xml")).read()
+    >>> getcapsin = open(resource_file("wfs_CUZK_GetCapabilities_2_0_0.xml"), 'rb').read()
     >>> wfs = WebFeatureService('http://services.cuzk.cz/wfs/inspire-cp-wfs.asp', xml=getcapsin, version='2.0.0')
 
 Test the capabilities info

--- a/tests/doctests/wfs_MapServerWFSCapabilities.txt
+++ b/tests/doctests/wfs_MapServerWFSCapabilities.txt
@@ -8,7 +8,7 @@ Imports
 
 Fake a request to a WFS Server using saved doc from.
 
-    >>> xml = open(resource_file('mapserver-wfs-cap.xml'), 'r').read()
+    >>> xml = open(resource_file('mapserver-wfs-cap.xml'), 'rb').read()
     >>> wfs = WebFeatureService('url', version='1.0', xml=xml)
 
 Test capabilities

--- a/tests/doctests/wml10_cuahsi.txt
+++ b/tests/doctests/wml10_cuahsi.txt
@@ -6,7 +6,7 @@ Imports
 
 Test GetSiteInfo
 
-	>>> f = open(resource_file('cuahsi_example_get_siteinfo_10.xml'), 'r').read()
+	>>> f = open(resource_file('cuahsi_example_get_siteinfo_10.xml'), 'rb').read()
 	>>> response = wml(f).response
 
 	>>> response.site_names

--- a/tests/doctests/wml11_cuahsi.txt
+++ b/tests/doctests/wml11_cuahsi.txt
@@ -7,7 +7,7 @@ Imports
 	>>> from owslib.waterml.wml11 import WaterML_1_1 as wml
 
 An example GetSites response (from cuahsi)
-	>>> f = open(resource_file('cuahsi_example_all_sites.xml'), 'r').read()
+	>>> f = open(resource_file('cuahsi_example_all_sites.xml'), 'rb').read()
 	>>> sites = wml(f).response
 
 Can view the queryInfo structure for information about the query

--- a/tests/doctests/wms_GeoServerCapabilities.txt
+++ b/tests/doctests/wms_GeoServerCapabilities.txt
@@ -8,7 +8,7 @@ Fake a request to a WMS Server using saved doc from GeoServer, using a subset
 of the sample data distributed with the installer.
 http://localhost:8080/geoserver/wms?request=GetCapabilities
 
-    >>> xml = open(resource_file('wms_geoserver-cap.xml'), 'r').read() 
+    >>> xml = open(resource_file('wms_geoserver-cap.xml'), 'rb').read() 
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
     
 Test capabilities

--- a/tests/doctests/wms_JPLCapabilities.txt
+++ b/tests/doctests/wms_JPLCapabilities.txt
@@ -9,7 +9,7 @@ Imports
 Fake a request to a WMS Server using saved doc from 
 http://wms.jpl.nasa.gov/wms.cgi.
 
-    >>> xml = open(resource_file('wms_JPLCapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('wms_JPLCapabilities.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
     
 Test capabilities

--- a/tests/doctests/wms_MesonetCapabilities.txt
+++ b/tests/doctests/wms_MesonetCapabilities.txt
@@ -9,7 +9,7 @@ Imports
 Fake a request to a WMS Server using saved doc from 
 http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi?
 
-    >>> xml = open(resource_file('wms_mesonet-caps.xml'), 'r').read()
+    >>> xml = open(resource_file('wms_mesonet-caps.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
     
 Test capabilities

--- a/tests/doctests/wms_TelaCapabilities.txt
+++ b/tests/doctests/wms_TelaCapabilities.txt
@@ -9,7 +9,7 @@ Imports
 Fake a request to a WMS Server using saved doc from telascience.org.
 http://wms.telascience.org/cgi-bin/ngBM_wms?
 
-    >>> xml = open(resource_file('wms_Telascience.xml'), 'r').read() 
+    >>> xml = open(resource_file('wms_Telascience.xml'), 'rb').read() 
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
     
 Test capabilities

--- a/tests/doctests/wms_geoserver_mass_gis.txt
+++ b/tests/doctests/wms_geoserver_mass_gis.txt
@@ -9,7 +9,7 @@ Imports
 Fake a request to a GeoServer WMS Server using saved doc from 
 http://giswebservices.massgis.state.ma.us/geoserver/wms
 
-    >>> xml = open(resource_file('wms_mass_gis-caps.xml'), 'r').read()
+    >>> xml = open(resource_file('wms_mass_gis-caps.xml'), 'rb').read()
     >>> wms = WebMapService('url', version='1.1.1', xml=xml)
     
 Test capabilities

--- a/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
+++ b/tests/doctests/wmts_EOSDISWMTSCapabilities.txt
@@ -8,7 +8,7 @@ Imports
 Fake a request to a WMTS Server using saved doc from
 http://map1b.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi
 
-    >>> xml = open(resource_file('eosdis-wmts-cap.xml'), 'r').read()
+    >>> xml = open(resource_file('eosdis-wmts-cap.xml'), 'rb').read()
     >>> wmts = WebMapTileService('url', version='1.0.0', xml=xml)
 
 Test capabilities

--- a/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
+++ b/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
@@ -8,7 +8,7 @@ Imports
 Fake a request to a WMTS Server using saved doc from
 http://server.caris.com/spatialfusionserver/services/ows/wmts/World/1.0.0/WMTSCapabilities.xml
 
-    >>> xml = open(resource_file('sfs-wmts-cap-world.xml'), 'r').read()
+    >>> xml = open(resource_file('sfs-wmts-cap-world.xml'), 'rb').read()
     >>> wmts = WebMapTileService('url', version='1.0.0', xml=xml)
 
 Test capabilities

--- a/tests/doctests/wmts_geoserver21.txt
+++ b/tests/doctests/wmts_geoserver21.txt
@@ -8,7 +8,7 @@ Imports
 Fake a request to a WMTS Server using saved doc from 
 http://geonode.iwlearn.org/geoserver/gwc/service/wmts?REQUEST=GetCapabilities
 
-    >>> xml = open(resource_file('geoserver21-wmts-cap.xml'), 'r').read() 
+    >>> xml = open(resource_file('geoserver21-wmts-cap.xml'), 'rb').read() 
     >>> wmts = WebMapTileService('url', version='1.0.0', xml=xml)
     
 Test capabilities

--- a/tests/doctests/wps_describeprocess_ceda.txt
+++ b/tests/doctests/wps_describeprocess_ceda.txt
@@ -13,7 +13,7 @@ Initialize WPS client
 
 Execute fake invocation of DescribeProcess operation by parsing cached response from USGS service
 
-    >>> xml = open(resource_file('wps_CEDADescribeProcess.xml'), 'r').read()
+    >>> xml = open(resource_file('wps_CEDADescribeProcess.xml'), 'rb').read()
     >>> process = wps.describeprocess('Doubleit', xml=xml)
 
 Check process description

--- a/tests/doctests/wps_describeprocess_usgs.txt
+++ b/tests/doctests/wps_describeprocess_usgs.txt
@@ -13,7 +13,7 @@ Initialize WPS client
 
 Execute fake invocation of DescribeProcess operation by parsing cached response from USGS service
 
-    >>> xml = open(resource_file('wps_USGSDescribeProcess.xml'), 'r').read()
+    >>> xml = open(resource_file('wps_USGSDescribeProcess.xml'), 'rb').read()
     >>> process = wps.describeprocess('gov.usgs.cida.gdp.wps.algorithm.FeatureWeightedGridStatisticsAlgorithm', xml=xml)
 
 Check process description

--- a/tests/doctests/wps_execute.txt
+++ b/tests/doctests/wps_execute.txt
@@ -14,8 +14,8 @@ Initialize WPS client
 
 Execute fake invocation of Execute operation using cached HTTP request and response
 
-    >>> request = open(resource_file('wps_USGSExecuteRequest1.xml'), 'r').read()
-    >>> response = open(resource_file('wps_USGSExecuteResponse1a.xml'), 'r').read()
+    >>> request = open(resource_file('wps_USGSExecuteRequest1.xml'), 'rb').read()
+    >>> response = open(resource_file('wps_USGSExecuteResponse1a.xml'), 'rb').read()
     >>> execution = wps.execute(None, [], request=request, response=response)
     Executing WPS request...
     Execution status=ProcessStarted
@@ -28,7 +28,7 @@ Execute fake invocation of Execute operation using cached HTTP request and respo
 
 Simulate end of process
 
-    >>> response = open(resource_file('wps_USGSExecuteResponse1b.xml'), 'r').read()
+    >>> response = open(resource_file('wps_USGSExecuteResponse1b.xml'), 'rb').read()
     >>> execution.checkStatus(sleepSecs=0, response=response)
     Execution status=ProcessSucceeded
     Percent completed=0

--- a/tests/doctests/wps_execute_invalid_request.txt
+++ b/tests/doctests/wps_execute_invalid_request.txt
@@ -13,8 +13,8 @@ Initialize WPS client
     >>> wps = WebProcessingService('http://cida.usgs.gov/gdp/process/WebProcessingService')
 
 Submit fake invocation of Execute operation using cached HTTP request and response
-    >>> request = open(resource_file('wps_USGSExecuteInvalidRequest.xml'), 'r').read()
-    >>> response = open(resource_file('wps_USGSExecuteInvalidRequestResponse.xml'), 'r').read()
+    >>> request = open(resource_file('wps_USGSExecuteInvalidRequest.xml'), 'rb').read()
+    >>> response = open(resource_file('wps_USGSExecuteInvalidRequestResponse.xml'), 'rb').read()
     >>> execution = wps.execute(None, [], request=request, response=response)
     Executing WPS request...
     Execution status=ProcessFailed

--- a/tests/doctests/wps_getcapabilities_ceda.txt
+++ b/tests/doctests/wps_getcapabilities_ceda.txt
@@ -13,7 +13,7 @@ Initialize WPS client
 
 Execute fake invocation of GetCapabilities operation by parsing cached response from USGS service
 
-    >>> xml = open(resource_file('wps_CEDACapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('wps_CEDACapabilities.xml'), 'rb').read()
     >>> wps.getcapabilities(xml=xml)
 
 Check WPS description

--- a/tests/doctests/wps_getcapabilities_usgs.txt
+++ b/tests/doctests/wps_getcapabilities_usgs.txt
@@ -13,7 +13,7 @@ Initialize WPS client
 
 Execute fake invocation of GetCapabilities operation by parsing cached response from USGS service
 
-    >>> xml = open(resource_file('wps_USGSCapabilities.xml'), 'r').read()
+    >>> xml = open(resource_file('wps_USGSCapabilities.xml'), 'rb').read()
     >>> wps.getcapabilities(xml=xml)
 
 Check WPS description

--- a/tests/doctests/wps_request2.txt
+++ b/tests/doctests/wps_request2.txt
@@ -44,7 +44,7 @@ Supply process input arguments
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_USGSExecuteRequest2.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_USGSExecuteRequest2.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True
 

--- a/tests/doctests/wps_request3.txt
+++ b/tests/doctests/wps_request3.txt
@@ -41,7 +41,7 @@ Supply process input arguments
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_USGSExecuteRequest3.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_USGSExecuteRequest3.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True
     

--- a/tests/doctests/wps_request4.txt
+++ b/tests/doctests/wps_request4.txt
@@ -22,6 +22,6 @@ Process input/ouutput arguments
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_PMLExecuteRequest4.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_PMLExecuteRequest4.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True

--- a/tests/doctests/wps_request5.txt
+++ b/tests/doctests/wps_request5.txt
@@ -22,6 +22,6 @@ Process input/ouutput arguments
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_PMLExecuteRequest5.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_PMLExecuteRequest5.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True

--- a/tests/doctests/wps_request6.txt
+++ b/tests/doctests/wps_request6.txt
@@ -22,6 +22,6 @@ Build XML request for WPS process execution
 
 Compare to cached XML request
 
-    >>> _request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'r').read()
+    >>> _request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'rb').read()
     >>> compare_xml(request, _request)
     True

--- a/tests/doctests/wps_response6.txt
+++ b/tests/doctests/wps_response6.txt
@@ -8,8 +8,8 @@ Instantiate WPS
 
 Execute face WPS invocation
 
-    >>> request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'r').read()
-    >>> response = open(resource_file('wps_PMLExecuteResponse6.xml'), 'r').read()
+    >>> request = open(resource_file('wps_PMLExecuteRequest6.xml'), 'rb').read()
+    >>> response = open(resource_file('wps_PMLExecuteResponse6.xml'), 'rb').read()
     >>> 
     >>> execution = wps.execute(None, [], request=request, response=response)
     Executing WPS request...


### PR DESCRIPTION
Some patches to help with https://github.com/geopython/OWSLib/issues/111. I think I have broken tests/doctests/wfs_MapServerWFSFeature.txt in python2.

One of the remaining problem I still have with bytes is the following (impacts two test):

```
UNEXPECTED EXCEPTION: TypeError('initial_value must be str or None, not bytes',)
Traceback (most recent call last):

  File "/usr/lib64/python3.4/doctest.py", line 1324, in __run
    compileflags, 1), test.globs)

  File "<doctest wfs_USDASSURGO.txt[4]>", line 1, in <module>

  File "/home/jenselme/projects/OWSLib/owslib/feature/wfs100.py", line 241, in getfeature
    return StringIO(data)

TypeError: initial_value must be str or None, not bytes

/home/jenselme/projects/OWSLib/tests/doctests/wfs_USDASSURGO.txt:8: UnexpectedException
```

It comes from the fact that in Python 3, StringIO can only handle strings and that bytes must be handled with BytesIO.
