### PR TITLE
Correct UnicodeDecodeError in python2

### DIFF
--- a/tests/doctests/wfs_MapServerWFSCapabilities.txt
+++ b/tests/doctests/wfs_MapServerWFSCapabilities.txt
@@ -100,6 +100,6 @@ Test exceptions
 Lastly, test the getcapabilities method
 
     >>> wfs = WebFeatureService('http://nsidc.org/cgi-bin/atlas_south?', version='1.0')
-    >>> xml = wfs.getcapabilities().read().decode()
+    >>> xml = wfs.getcapabilities().read().decode('utf-8')
     >>> xml.find('<WFS_Capabilities') > 0
     True


### PR DESCRIPTION
In wfs_MapServerWFSCapabilities.txt, the response contains non ascii
characters. We now precise the encoding the the response is correctly
decoded.
