### PR TITLE
Correct wmts_SFSWorldWMTSCapabilities.txt for python3

### DIFF
--- a/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
+++ b/tests/doctests/wmts_SFSWorldWMTSCapabilities.txt
@@ -223,15 +223,18 @@ Test operations
 
 Test the gettile methods
     >>> try:
+    ...     from io import BytesIO as ImageIO
+    ... except ImportError:
+    ...     from cStringIO import StringIO as ImageIO
+    >>> try:
     ...     from PIL import Image
     ... except:
     ...     pass
     ... else:
     ...     rq = wmts.buildTileRequest(layer='World', tilematrix='0', row=0, column=0)
     ...     assert rq == 'SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=World&STYLE=default&TILEMATRIXSET=GlobalCRS84Scale&TILEMATRIX=0&TILEROW=0&TILECOL=0&FORMAT=image%2Fpng'
-    ...     import cStringIO
     ...     tile000 = wmts.gettile(layer='World', tilematrix='0', row=0, column=0)
-    ...     im = cStringIO.StringIO(tile000.read())
+    ...     im = ImageIO(tile000.read())
     ...     image = Image.open(im)
     ...     assert image.size == (256, 256)
 


### PR DESCRIPTION
- cStringIO doesn't exist in python3
- PIL.Image take a BytesIO in python3 whereas it takes a StringIO in python2
